### PR TITLE
fix: Some skin wearables not rendering in avatar view

### DIFF
--- a/Assets/Scripts/Loading/AvatarLoader.cs
+++ b/Assets/Scripts/Loading/AvatarLoader.cs
@@ -156,8 +156,8 @@ namespace Loading
                 go.SetActive(true);
                 outlineRenderers.Clear();
 
-                // Colors
-                AvatarUtils.SetupColors(go, colors, outlineRenderers, avatarRootBone, avatarBones);
+                AvatarUtils.SetupColors(go, colors, outlineRenderers);
+                AvatarUtils.RebindBones(go, avatarRootBone, avatarBones);
 
                 if (hiddenCategories.Contains(ed.Category))
                 {

--- a/Assets/Scripts/Utils/AvatarUtils.cs
+++ b/Assets/Scripts/Utils/AvatarUtils.cs
@@ -163,8 +163,7 @@ namespace Utils
             }
         }
 
-        public static void SetupColors(GameObject go, AvatarColors colors,
-            List<Renderer> outlineRenderers, Transform avatarRootBone = null, Transform[] avatarBones = null)
+        public static void SetupColors(GameObject go, AvatarColors colors, List<Renderer> outlineRenderers)
         {
             var renderers = go.GetComponentsInChildren<SkinnedMeshRenderer>();
             foreach (var r in renderers)
@@ -178,17 +177,18 @@ namespace Utils
                     r.material.SetColor(WearablesConstants.Shaders.BASE_COLOR_ID, colors.Hair);
                 }
 
-                if (avatarRootBone != null && avatarBones != null)
-                {
-                    r.rootBone = avatarRootBone;
-                    r.bones = avatarBones;
-                }
-
                 if (r.material.shader.name == "DCL/DCL_Toon" && r.sharedMaterial.renderQueue is >= 2000 and < 3000)
                 {
                     outlineRenderers.Add(r);
                 }
             }
+        }
+
+        public static void RebindBones(GameObject go, Transform avatarRootBone, Transform[] avatarBones)
+        {
+            var renderers = go.GetComponentsInChildren<SkinnedMeshRenderer>();
+            foreach (var r in renderers)
+                RebindBones(r, avatarRootBone, avatarBones);
         }
 
         public static void SetupFacialFeatures(GameObject go, AvatarColors colors,
@@ -251,6 +251,37 @@ namespace Utils
                 WearableCategories.Categories.MOUTH => colors.Skin,
                 _ => throw new ArgumentOutOfRangeException(nameof(category), category, null)
             };
+        }
+
+        /// <summary>
+        /// Rebinds bones by matching names. Bones that match the avatar skeleton are replaced
+        /// so they animate together. Bones with no match keep their original transform, which
+        /// is essential for skin wearables that may have non-standard skeletons.
+        /// </summary>
+        private static void RebindBones(SkinnedMeshRenderer renderer, Transform avatarRootBone, Transform[] avatarBones)
+        {
+            var currentBones = renderer.bones;
+
+            // Build a lookup from bone name to avatar bone transform
+            var avatarBoneLookup = new Dictionary<string, Transform>(avatarBones.Length);
+
+            foreach (var bone in avatarBones)
+            {
+                if (bone != null)
+                    avatarBoneLookup[bone.name] = bone;
+            }
+
+            var newBones = new Transform[currentBones.Length];
+            for (var i = 0; i < currentBones.Length; i++)
+            {
+                if (currentBones[i] != null && avatarBoneLookup.TryGetValue(currentBones[i].name, out var match))
+                    newBones[i] = match;
+                else
+                    newBones[i] = currentBones[i];
+            }
+
+            renderer.rootBone = avatarBoneLookup.GetValueOrDefault(renderer.rootBone?.name ?? "", avatarRootBone);
+            renderer.bones = newBones;
         }
     }
 }


### PR DESCRIPTION
Fix: https://github.com/decentraland/unity-explorer/issues/7325

## Problem
Skin wearables with non-standard skeletons (e.g. "LilDoge" — a dog character) were invisible in avatar view. The root cause was that SetupColors blindly replaced all SkinnedMeshRenderer.bones with the standard humanoid avatar bones array. When a skin has a completely different skeleton (different bone count/structure), this collapsed the mesh to nothing. In WebGL/WASM builds, this also triggered a `RuntimeError: divide by zero` because Unity's internal rendering code attempted to compute normals/matrices on the collapsed mesh.

## Fix
  - Separated bone rebinding from color setup — SetupColors now only handles materials, and a new RebindBones method handles skeleton binding. These were mixed responsibilities in a single method.
  - RebindBones matches bones by name instead of replacing the entire array. Bones that exist in the avatar skeleton are replaced so they animate together, while bones with no match keep their original transform from the GLB. This ensures skin wearables with custom skeletons render and animate correctly.