### PR TITLE
fix: emotes in builder mode

### DIFF
--- a/Assets/JSPlugin/JSBridge.jslib
+++ b/Assets/JSPlugin/JSBridge.jslib
@@ -117,10 +117,67 @@ mergeInto(LibraryManager.library, {
       '*'
     )
   },
+  OnEmoteLength: function (length) {
+    const targetWindow = (() => {
+      try {
+        return window.self !== window.top ? window : window.parent
+      } catch (e) {
+        return window.parent
+      }
+    })()
+    targetWindow.postMessage(
+      {
+        type: 'unity-renderer',
+        payload: {
+          type: 'emoteLength',
+          payload: length,
+        },
+      },
+      '*'
+    )
+  },
+  OnIsEmotePlaying: function (playing) {
+    const targetWindow = (() => {
+      try {
+        return window.self !== window.top ? window : window.parent
+      } catch (e) {
+        return window.parent
+      }
+    })()
+    targetWindow.postMessage(
+      {
+        type: 'unity-renderer',
+        payload: {
+          type: 'isEmotePlaying',
+          payload: !!playing,
+        },
+      },
+      '*'
+    )
+  },
+  OnHasSound: function (hasSound) {
+    const targetWindow = (() => {
+      try {
+        return window.self !== window.top ? window : window.parent
+      } catch (e) {
+        return window.parent
+      }
+    })()
+    targetWindow.postMessage(
+      {
+        type: 'unity-renderer',
+        payload: {
+          type: 'hasSound',
+          payload: !!hasSound,
+        },
+      },
+      '*'
+    )
+  },
   PreloadURLs: function(strPtr) {
     const csv = UTF8ToString(strPtr);
     const urls = csv.split(',');
-     
+
     for (const url of urls) {
       fetch(url, { cache: 'force-cache' }).catch(() => {});
     }

--- a/Assets/Scripts/EmoteAnimationController.cs
+++ b/Assets/Scripts/EmoteAnimationController.cs
@@ -11,11 +11,14 @@ public class EmoteAnimationController : MonoBehaviour
     [SerializeField] private Animation avatarAnimation;
 
     public bool HasAudio => _emoteAudioClip != null;
+    public bool IsPaused => _paused;
     public event Action EmoteAnimationEnded;
 
     private LoadedEmote? _loadedEmote;
     private Animation _propAnimation;
     private AudioClip _emoteAudioClip;
+    private bool _paused;
+    private float _pausedTime;
 
     public void PlayEmote(LoadedEmote loadedEmote)
     {
@@ -44,9 +47,23 @@ public class EmoteAnimationController : MonoBehaviour
         ReplayEmote();
     }
 
+    public float GetEmoteLength()
+    {
+        if (!_loadedEmote.HasValue) return 0f;
+        return _loadedEmote.Value.Clip.length;
+    }
+
+    public bool IsEmotePlaying()
+    {
+        if (!_loadedEmote.HasValue) return false;
+        return avatarAnimation.IsPlaying(_loadedEmote.Value.Entity.URN);
+    }
+
     public void ReplayEmote()
     {
         if (!_loadedEmote.HasValue) return;
+
+        _paused = false;
 
         // Prop
         if (_propAnimation != null)
@@ -68,9 +85,50 @@ public class EmoteAnimationController : MonoBehaviour
         }
     }
 
+    public void PauseEmote()
+    {
+        if (!_loadedEmote.HasValue) return;
+        if (!avatarAnimation.IsPlaying(_loadedEmote.Value.Entity.URN)) return;
+
+        _paused = true;
+        _pausedTime = GetCurrentEmoteTime();
+
+        // Pause by setting speed to 0
+        var state = avatarAnimation[_loadedEmote.Value.Entity.URN];
+        if (state != null) state.speed = 0f;
+
+        if (_propAnimation != null)
+        {
+            var propState = _propAnimation[_loadedEmote.Value.Entity.URN];
+            if (propState != null) propState.speed = 0f;
+        }
+
+        audioSource.Pause();
+    }
+
+    public void ResumeEmote()
+    {
+        if (!_loadedEmote.HasValue || !_paused) return;
+
+        _paused = false;
+
+        var state = avatarAnimation[_loadedEmote.Value.Entity.URN];
+        if (state != null) state.speed = 1f;
+
+        if (_propAnimation != null)
+        {
+            var propState = _propAnimation[_loadedEmote.Value.Entity.URN];
+            if (propState != null) propState.speed = 1f;
+        }
+
+        audioSource.UnPause();
+    }
+
     public void StopEmote(bool withCrossFade = true)
     {
         if (!_loadedEmote.HasValue) return;
+
+        _paused = false;
 
         audioSource.Stop();
         if (_propAnimation != null)
@@ -86,6 +144,66 @@ public class EmoteAnimationController : MonoBehaviour
         {
             avatarAnimation.Play(IDLE_CLIP_NAME, PlayMode.StopAll);
         }
+    }
+
+    public void GoToEmote(float seconds)
+    {
+        if (!_loadedEmote.HasValue) return;
+
+        var urn = _loadedEmote.Value.Entity.URN;
+        var wasPaused = _paused;
+
+        // Ensure the animation is playing so we can seek it
+        if (!avatarAnimation.IsPlaying(urn))
+        {
+            avatarAnimation.Play(urn);
+        }
+
+        var state = avatarAnimation[urn];
+        if (state != null)
+        {
+            state.time = seconds;
+            // If it was paused (or we want to just seek), keep it paused
+            if (wasPaused)
+            {
+                state.speed = 0f;
+            }
+        }
+
+        avatarAnimation.Sample();
+
+        if (_propAnimation != null)
+        {
+            var propState = _propAnimation[urn];
+            if (propState != null)
+            {
+                propState.time = seconds;
+                if (wasPaused) propState.speed = 0f;
+            }
+        }
+
+        // Sync audio position
+        if (_emoteAudioClip != null && audioSource.isPlaying)
+        {
+            audioSource.time = Mathf.Clamp(seconds, 0f, _emoteAudioClip.length);
+        }
+    }
+
+    public void EnableSound()
+    {
+        if (audioSource != null) audioSource.volume = 1f;
+    }
+
+    public void DisableSound()
+    {
+        if (audioSource != null) audioSource.volume = 0f;
+    }
+
+    private float GetCurrentEmoteTime()
+    {
+        if (!_loadedEmote.HasValue) return 0f;
+        var state = avatarAnimation[_loadedEmote.Value.Entity.URN];
+        return state?.time ?? 0f;
     }
 
     public void ClearEmote()

--- a/Assets/Scripts/JSBridge.cs
+++ b/Assets/Scripts/JSBridge.cs
@@ -85,6 +85,33 @@ public class JSBridge : MonoBehaviour
     public void GetElementBounds(string elementName) => configuratorUIPresenter.GetElementBounds(elementName);
 
     [UsedImplicitly]
+    public void GetEmoteLength() => NativeCalls.OnEmoteLength(previewController.GetEmoteLength());
+
+    [UsedImplicitly]
+    public void IsEmotePlaying() => NativeCalls.OnIsEmotePlaying(previewController.IsEmotePlaying());
+
+    [UsedImplicitly]
+    public void PlayEmote() => previewController.PlayEmote();
+
+    [UsedImplicitly]
+    public void PauseEmote() => previewController.PauseEmote();
+
+    [UsedImplicitly]
+    public void GoToEmote(string value) => previewController.GoToEmote(float.Parse(value));
+
+    [UsedImplicitly]
+    public void StopEmote() => previewController.StopEmote();
+
+    [UsedImplicitly]
+    public void EnableSound() => previewController.EnableSound();
+
+    [UsedImplicitly]
+    public void DisableSound() => previewController.DisableSound();
+
+    [UsedImplicitly]
+    public void HasSound() => NativeCalls.OnHasSound(previewController.HasSound());
+
+    [UsedImplicitly]
     public void Reload() => previewController.InvokeReload();
 
     [UsedImplicitly]
@@ -150,12 +177,18 @@ public class JSBridge : MonoBehaviour
         public static void OnLoadComplete() => Debug.Log("NativeCall OnLoadComplete");
 
         public static void OnError(string message) => Debug.LogError($"NativeCall OnError({message})");
-        
+
         public static void OnCustomizationDone(string message) => Debug.Log($"NativeCall OnCustomizationDone({message})");
 
         public static void OnElementBounds(string json) => Debug.Log($"NativeCall OnElementBounds({json})");
 
         public static void OnAvatarCustomizationStep(int step) => Debug.Log($"NativeCall OnAvatarCustomizationStep({step})");
+
+        public static void OnEmoteLength(float length) => Debug.Log($"NativeCall OnEmoteLength({length})");
+
+        public static void OnIsEmotePlaying(bool playing) => Debug.Log($"NativeCall OnIsEmotePlaying({playing})");
+
+        public static void OnHasSound(bool hasSound) => Debug.Log($"NativeCall OnHasSound({hasSound})");
 
         // ReSharper disable once InconsistentNaming
         public static void PreloadURLs(string urlsCSV) => Debug.Log($"NativeCall PreloadURLs({urlsCSV})");
@@ -177,6 +210,15 @@ public class JSBridge : MonoBehaviour
 
         [System.Runtime.InteropServices.DllImport("__Internal")]
         public static extern void OnAvatarCustomizationStep(int step);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        public static extern void OnEmoteLength(float length);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        public static extern void OnIsEmotePlaying(bool playing);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        public static extern void OnHasSound(bool hasSound);
 
         [System.Runtime.InteropServices.DllImport("__Internal")]
         public static extern void PreloadURLs(string urlsCSV);

--- a/Assets/Scripts/Loading/AvatarLoader.cs
+++ b/Assets/Scripts/Loading/AvatarLoader.cs
@@ -81,8 +81,6 @@ namespace Loading
                 ? await GLTFLoader.LoadEmote(bodyShape, emoteDefinition, transform)
                 : (LoadedEmote?)null;
 
-            Debug.Log("EMOTE LOADED");
-
             var emoteChanged = _loadedEmote?.Entity.URN != emoteDefinition?.URN;
 
             // Clean up previous emote prop / audio
@@ -190,6 +188,16 @@ namespace Loading
             if (bodyGO != null)
             {
                 AvatarUtils.HideBodyShapeFacialFeatures(bodyGO, true, true, true);
+            }
+        }
+
+        public void ClearEmote()
+        {
+            if (_loadedEmote != null)
+            {
+                _loadedEmote.Value.Disposable?.Dispose();
+                Destroy(_loadedEmote.Value.Prop);
+                _loadedEmote = null;
             }
         }
 

--- a/Assets/Scripts/Preview/PreviewController.cs
+++ b/Assets/Scripts/Preview/PreviewController.cs
@@ -82,6 +82,30 @@ namespace Preview
             avatarRotator.ResetRotation();
         }
 
+        public float GetEmoteLength() => emoteAnimationController.GetEmoteLength();
+
+        public bool IsEmotePlaying() => emoteAnimationController.IsEmotePlaying();
+
+        public void PlayEmote()
+        {
+            if (emoteAnimationController.IsPaused)
+                emoteAnimationController.ResumeEmote();
+            else
+                emoteAnimationController.ReplayEmote();
+        }
+
+        public void PauseEmote() => emoteAnimationController.PauseEmote();
+
+        public void GoToEmote(float seconds) => emoteAnimationController.GoToEmote(seconds);
+
+        public void StopEmote() => emoteAnimationController.StopEmote();
+
+        public void EnableSound() => emoteAnimationController.EnableSound();
+
+        public void DisableSound() => emoteAnimationController.DisableSound();
+
+        public bool HasSound() => emoteAnimationController.HasAudio;
+
         public void InvokeReload()
         {
             _shouldCleanup = false;
@@ -252,8 +276,8 @@ namespace Preview
 
             var colors = new AvatarColors(eyeColor ?? Color.black, hairColor ?? Color.black, skinColor ?? Color.black);
 
-            var emoteEntity = base64Emote ?? EntityDefinition.FromEmbeddedEmote(emoteName, true);
-            
+            var emoteEntity = base64Emote ?? (emoteName == "idle" ? null : EntityDefinition.FromEmbeddedEmote(emoteName, true));
+
             await avatarLoader.LoadAvatar(bodyShape,
                 wearableEntities,
                 emoteEntity,
@@ -362,6 +386,7 @@ namespace Preview
             _shouldCleanup = false;
 
             emoteAnimationController.ClearEmote();
+            avatarLoader.ClearEmote();
         }
     }
 }


### PR DESCRIPTION
# fix: emotes in builder mode

#### Related PRs

- Wearable Preview: https://github.com/decentraland/wearable-preview/pull/161
- Builder: https://github.com/decentraland/builder/pull/3275

### Summary

This pull request adds support for controlling and querying emote playback in the Unity wearable preview, including play, pause, seek, stop, and sound controls, as well as communication between Unity and JavaScript for these features. The changes introduce new methods in the emote animation controller, expose them through the JS bridge, and ensure proper state handling and cleanup.

**Emote Playback Controls:**

- Added methods to `EmoteAnimationController` for pausing, resuming, seeking (`GoToEmote`), enabling/disabling sound, and querying emote state (length, playing, paused, has sound). These allow for fine-grained control of emote playback. [[1]](diffhunk://#diff-29b3cdc0e02700aa6e7a56f2b50bd1ea2060f834b9aea9026ebe4f4027c342f1R14-R21) [[2]](diffhunk://#diff-29b3cdc0e02700aa6e7a56f2b50bd1ea2060f834b9aea9026ebe4f4027c342f1R50-R67) [[3]](diffhunk://#diff-29b3cdc0e02700aa6e7a56f2b50bd1ea2060f834b9aea9026ebe4f4027c342f1R88-R132) [[4]](diffhunk://#diff-29b3cdc0e02700aa6e7a56f2b50bd1ea2060f834b9aea9026ebe4f4027c342f1R149-R208)

- Updated `PreviewController` to expose these controls and state queries, delegating to `EmoteAnimationController`.

**JS Bridge Integration:**

- Exposed the new emote control and query methods to JavaScript via `JSBridge`, enabling JS to control emote playback and receive state updates from Unity.

- Implemented corresponding native calls and message handlers in `JSBridge.jslib` for communication between Unity and the browser, including posting emote state updates. [[1]](diffhunk://#diff-5710d1919f589bf9121cc3345d1281835dd2d31c42ba2fe53111829d88a9be79R120-R176) [[2]](diffhunk://#diff-e49bcf289ec4c04a9b97281d525c20014bac863acd74f77c1198182a746070bcR187-R192) [[3]](diffhunk://#diff-e49bcf289ec4c04a9b97281d525c20014bac863acd74f77c1198182a746070bcR214-R222)

**Emote State Management and Cleanup:**

- Improved emote cleanup by adding a `ClearEmote` method to both `AvatarLoader` and `PreviewController`, ensuring proper disposal and state reset when cleaning up emotes. [[1]](diffhunk://#diff-7222c1db19726ad4e8fe64a2d5d1f218e9e41b28ef1cfb36a7476151dac1f8d6R194-R203) [[2]](diffhunk://#diff-bef22146f4f6915eb601242a3b941d278a4e892603ec47ad88bbd0b46d7ec115R389)

**Other Adjustments:**

- Prevented loading the "idle" emote as an embedded emote, ensuring it is treated as a null emote to avoid fallback to T-pose.

- Removed a debug log statement from the emote loading process for cleaner logs.