### PR TITLE
fix: spring bone root detection

### DIFF
--- a/Assets/Scripts/Utils/AvatarUtils.cs
+++ b/Assets/Scripts/Utils/AvatarUtils.cs
@@ -325,7 +325,7 @@ namespace Utils
 
                 // Extra bone (e.g. spring bone) whose direct parent is a wearable copy of an avatar bone.
                 // Re-parent under the live avatar bone so it follows the avatar during emotes.
-                                // Descendants within the chain keep their existing parent, preserving chain structure.
+                // Descendants within the chain keep their existing parent, preserving chain structure.
                 if (transform.parent != null
                     && avatarBoneMap.TryGetValue(transform.parent.name, out var liveParent)
                     && transform.parent != liveParent)

--- a/Assets/Scripts/Utils/AvatarUtils.cs
+++ b/Assets/Scripts/Utils/AvatarUtils.cs
@@ -313,27 +313,22 @@ namespace Utils
         private static void ReparentExtraBonesUnderAvatarSkeleton(GameObject wearableRoot,
             Dictionary<string, Transform> avatarBoneMap)
         {
-            // Collect all transforms in the wearable's hierarchy
             var allTransforms = wearableRoot.GetComponentsInChildren<Transform>(true);
-
-            // Build a set of all live avatar transforms for fast identity checks
-            var liveAvatarTransforms = new HashSet<Transform>(avatarBoneMap.Values);
 
             foreach (var transform in allTransforms)
             {
                 // Skip the root itself
                 if (transform == wearableRoot.transform) continue;
 
-                // Skip if this transform is itself a live avatar bone
-                if (liveAvatarTransforms.Contains(transform)) continue;
+                // Skip transforms that correspond to standard avatar bones (by name).
+                if (avatarBoneMap.ContainsKey(transform.name)) continue;
 
-                // Only re-parent chain roots: transforms whose direct parent is a live avatar bone.
-                // Descendants within the chain keep their existing parent, preserving chain structure.
-                if (transform.parent == null || !liveAvatarTransforms.Contains(transform.parent)) continue;
-
-                // The direct parent is a live avatar bone by identity, but it may be the wearable's
-                // copy of that bone rather than the actual live instance. Re-parent under the live one.
-                if (avatarBoneMap.TryGetValue(transform.parent.name, out var liveParent) && transform.parent != liveParent)
+                // Extra bone (e.g. spring bone) whose direct parent is a wearable copy of an avatar bone.
+                // Re-parent under the live avatar bone so it follows the avatar during emotes.
+                                // Descendants within the chain keep their existing parent, preserving chain structure.
+                if (transform.parent != null
+                    && avatarBoneMap.TryGetValue(transform.parent.name, out var liveParent)
+                    && transform.parent != liveParent)
                 {
                     transform.SetParent(liveParent, true);
                 }


### PR DESCRIPTION
## Summary

Related PR: #55 

This pull request refines the logic for reparenting extra bones (such as spring bones) in the `ReparentExtraBonesUnderAvatarSkeleton` method. The update ensures that only transforms not corresponding to standard avatar bones are considered for reparenting, and that extra bones are more reliably reparented under the correct live avatar bones by matching names rather than relying on object identity.

Bone reparenting improvements:

* Updated the check to skip transforms that correspond to standard avatar bones by name instead of by object identity, making the logic more robust to different object instances.
* Improved the condition for reparenting extra bones to ensure that only wearable copies of avatar bones are reparented under the live avatar bones, using name-based matching for the parent transform.

## Screenshots

BEFORE:

https://github.com/user-attachments/assets/9ecdcd4e-ff2f-491d-8235-31157a0d8f2f

AFTER:

https://github.com/user-attachments/assets/efdefdb0-f4bf-497f-871d-f86d897319b2