### PR TITLE
fix: frame emote previews via camera instead of scaling the avatar

### DIFF
--- a/Assets/Scripts/EmoteAnimationController.cs
+++ b/Assets/Scripts/EmoteAnimationController.cs
@@ -52,6 +52,94 @@ public class EmoteAnimationController : MonoBehaviour
         return _loadedEmote.Value.Clip.length;
     }
 
+    // Mesh extends beyond the bone joints; pad the bone-derived envelope so nothing clips.
+    private const float BoneEnvelopePadding = 0.15f;
+
+    /// <summary>
+    /// Samples the currently loaded emote across its whole length (plus the idle pose) and returns
+    /// the world-space envelope of the avatar skeleton over that range. Used to frame the camera so
+    /// the entire emote fits — sampling the whole clip avoids depending on any single animation
+    /// frame, and measuring bone positions (rather than SkinnedMeshRenderer.bounds, which does not
+    /// refresh on a synchronous Sample) captures the true animated extent, including emotes that
+    /// scale the avatar. The visible pose and playback state are fully restored before returning.
+    /// </summary>
+    public bool TryGetEmoteWorldBounds(Renderer[] renderers, int samples, out Bounds worldBounds)
+    {
+        worldBounds = default;
+
+        if (!_loadedEmote.HasValue || renderers == null || renderers.Length == 0) return false;
+        if (samples < 1) samples = 1;
+
+        var urn = _loadedEmote.Value.Entity.URN;
+        var clip = _loadedEmote.Value.Clip;
+
+        // Collect the unique set of skeleton bones driving the avatar. We measure the envelope from
+        // bone world positions rather than SkinnedMeshRenderer.bounds: skinned bounds do not
+        // recompute on a synchronous Sample() (Unity only refreshes them during its skinning pass),
+        // so they stay frozen while scrubbing. Bone transforms, however, update immediately — and
+        // they also track any scale the emote animates, which is exactly what we need to frame.
+        var bones = new System.Collections.Generic.HashSet<Transform>();
+        foreach (var r in renderers)
+        {
+            if (r is not SkinnedMeshRenderer smr) continue;
+            if (smr.rootBone != null) bones.Add(smr.rootBone);
+            foreach (var b in smr.bones)
+                if (b != null) bones.Add(b);
+        }
+
+        if (bones.Count == 0) return false;
+
+        var hasBounds = false;
+
+        avatarAnimation.Play(urn);
+        var state = avatarAnimation[urn];
+
+        if (state != null)
+        {
+            for (var i = 0; i <= samples; i++)
+            {
+                state.time = i / (float)samples * clip.length;
+                avatarAnimation.Sample();
+                EncapsulateBones(bones, ref worldBounds, ref hasBounds);
+            }
+        }
+
+        // Include the idle pose so the framing keeps the resting avatar comfortably inside.
+        avatarAnimation.Play(IDLE_CLIP_NAME);
+        avatarAnimation.Sample();
+        EncapsulateBones(bones, ref worldBounds, ref hasBounds);
+
+        if (hasBounds)
+        {
+            worldBounds.Expand(BoneEnvelopePadding * 2f); // Expand() takes total growth, so *2 per side.
+        }
+
+        // Restart the emote cleanly from the top (this re-establishes the crossfade-to-idle queue,
+        // prop and audio triggers) so sampling leaves playback exactly as a fresh play would.
+        ReplayEmote();
+
+        return hasBounds;
+    }
+
+    private static void EncapsulateBones(System.Collections.Generic.HashSet<Transform> bones,
+        ref Bounds bounds, ref bool hasBounds)
+    {
+        foreach (var b in bones)
+        {
+            if (b == null) continue;
+
+            if (!hasBounds)
+            {
+                bounds = new Bounds(b.position, Vector3.zero);
+                hasBounds = true;
+            }
+            else
+            {
+                bounds.Encapsulate(b.position);
+            }
+        }
+    }
+
     public bool IsEmotePlaying()
     {
         if (!_loadedEmote.HasValue) return false;

--- a/Assets/Scripts/Loading/AvatarLoader.cs
+++ b/Assets/Scripts/Loading/AvatarLoader.cs
@@ -301,6 +301,15 @@ namespace Loading
             }
         }
 
+        public Renderer[] GetAvatarRenderers() => transform.GetComponentsInChildren<Renderer>();
+
+        /// <summary>
+        /// World-space bounds of the loaded emote across its whole animation, used to frame the camera.
+        /// Returns false if there is no emote loaded or no renderers to measure.
+        /// </summary>
+        public bool TryGetEmoteBounds(int samples, out Bounds worldBounds) =>
+            emoteAnimationController.TryGetEmoteWorldBounds(GetAvatarRenderers(), samples, out worldBounds);
+
         public void ClearEmote()
         {
             if (_loadedEmote != null)

--- a/Assets/Scripts/Preview/PreviewCameraController.cs
+++ b/Assets/Scripts/Preview/PreviewCameraController.cs
@@ -11,6 +11,12 @@ namespace Preview
         [SerializeField] private float zoomStep = 5f;
         [SerializeField] private float lerpSpeed = 1f;
 
+        [Tooltip("Extra breathing room around the emote when framing (0.15 = 15% margin).")]
+        [SerializeField] private float framingPadding = 0.15f;
+
+        [Tooltip("Closest the avatar camera may dolly when framing, to avoid clipping into the mesh.")]
+        [SerializeField] private float minFramingDistance = 1f;
+
         [SerializeField] private CinemachineCamera authProfileCamera;
         [SerializeField] private CinemachineCamera marketplaceWearableCamera;
         [SerializeField] private CinemachineCamera marketplaceAvatarCamera;
@@ -19,13 +25,52 @@ namespace Preview
 
         private float _targetFOV;
         private float _initialFOV;
+        private float _initialOrthoSize;
+        private Vector3 _avatarCamInitialLocalPos;
 
         private void Awake()
         {
             _targetFOV = _initialFOV = marketplaceAvatarCamera.Lens.FieldOfView;
-            
+            _initialOrthoSize = marketplaceAvatarCamera.Lens.OrthographicSize;
+            _avatarCamInitialLocalPos = marketplaceAvatarCamera.transform.localPosition;
+
             // We prioritize this one because we want to have a cut to any other camera after this for the first time
             authProfileCamera.Prioritize();
+        }
+
+        /// <summary>
+        /// Frames the avatar camera so the given world-space emote bounds fit fully in view.
+        /// Framing only moves the camera (dolly + recenter); field of view is left to the zoom
+        /// controls so the two never fight. Reset back to the authored pose in <see cref="SetMode"/>.
+        /// </summary>
+        public void FrameAvatarToBounds(Bounds worldBounds, float aspect, bool orthographic)
+        {
+            var extents = worldBounds.extents;
+
+            if (orthographic)
+            {
+                // Distance is irrelevant in orthographic; size the lens instead.
+                var halfHeight = Mathf.Max(extents.y, extents.x / Mathf.Max(aspect, 0.0001f));
+                marketplaceAvatarCamera.Lens.OrthographicSize = halfHeight * (1f + framingPadding);
+                return;
+            }
+
+            // Fit distance using the tighter of the vertical/horizontal frustum so nothing clips,
+            // then add half the depth so the far face stays inside, then padding for breathing room.
+            var tanV = Mathf.Tan(_initialFOV * 0.5f * Mathf.Deg2Rad);
+            var distV = extents.y / tanV;
+            var distH = extents.x / (tanV * Mathf.Max(aspect, 0.0001f));
+            var dist = (Mathf.Max(distV, distH) + extents.z) * (1f + framingPadding);
+            dist = Mathf.Clamp(dist, minFramingDistance, marketplaceAvatarCamera.Lens.FarClipPlane);
+
+            var camTransform = marketplaceAvatarCamera.transform;
+
+            // Place the camera on its own (fixed-orientation) view axis, `dist` behind the bbox
+            // center. This guarantees the bbox center projects to screen center regardless of the
+            // camera's authored pitch — nudging the authored local position instead would mis-aim a
+            // tilted camera and push the subject out of frame.
+            var forward = camTransform.rotation * Vector3.forward;
+            camTransform.position = worldBounds.center - forward * dist;
         }
 
         public void SetMode(PreviewMode mode)
@@ -33,6 +78,10 @@ namespace Preview
             // Reset FOV when switching modes
             marketplaceAvatarCamera.Lens.FieldOfView = marketplaceWearableCamera.Lens.FieldOfView =
                 builderCamera.Lens.FieldOfView = _targetFOV = _initialFOV;
+
+            // Reset any per-emote framing so repeated reloads always start from the authored pose.
+            marketplaceAvatarCamera.transform.localPosition = _avatarCamInitialLocalPos;
+            marketplaceAvatarCamera.Lens.OrthographicSize = _initialOrthoSize;
 
             switch (mode)
             {

--- a/Assets/Scripts/Preview/PreviewController.cs
+++ b/Assets/Scripts/Preview/PreviewController.cs
@@ -32,6 +32,9 @@ namespace Preview
 
         [SerializeField] private float wearablePadding = 0.15f;
 
+        // Number of steps to sample across an emote clip when computing its framing bounds.
+        private const int EMOTE_BBOX_SAMPLES = 24;
+
         private bool _loading;
         private bool _shouldReload;
         private bool _shouldCleanup;
@@ -229,7 +232,14 @@ namespace Preview
                 }
                 else if (hasEmoteOverride)
                 {
-                    GameObjectUtils.CenterAndFit(avatarLoader.transform, mainCamera, wearablePadding);
+                    // Frame the emote by moving the camera (keeping the avatar at true world scale)
+                    // so the whole animation fits and the avatar never gets left over-scaled on the
+                    // return to idle. See marketplace#2661.
+                    if (avatarLoader.TryGetEmoteBounds(EMOTE_BBOX_SAMPLES, out var emoteBounds))
+                    {
+                        previewCameraController.FrameAvatarToBounds(emoteBounds, mainCamera.aspect,
+                            mainCamera.orthographic);
+                    }
                 }
 
                 if (config.Mode is PreviewMode.Marketplace)


### PR DESCRIPTION
## What

Fixes emote preview framing in marketplace mode. Previously the avatar was framed by **scaling the avatar transform** to fit the camera, using the renderers' bind-pose AABB, and the scale was baked in and never reset. This mis-scaled emotes whose real animated extent differed from the bind pose, and left the avatar **giant / too close to the camera** when a non-looping emote returned to idle.

Closes decentraland/aang-renderer#67.

## Approach

Keep the avatar at **true world scale** and frame the emote by **dollying the camera** to the emote's real animated extent:

- **`EmoteAnimationController.TryGetEmoteWorldBounds`** — scrubs the whole emote clip (plus the idle pose) and builds the world-space envelope from the avatar's **bone positions**.
  - We deliberately do **not** use `SkinnedMeshRenderer.bounds`: it does not refresh on a synchronous `Sample()` (Unity only recomputes skinned bounds during its skinning pass), so it stays frozen at the bind-pose box while scrubbing. Bone transforms update immediately and also track any scale the emote animates — which is exactly what we need to frame emotes that grow or shrink the avatar.
  - Playback is restored via `ReplayEmote()` so the crossfade-to-idle queue, prop, and audio are unaffected.
- **`AvatarLoader`** — exposes `GetAvatarRenderers` / `TryGetEmoteBounds`.
- **`PreviewCameraController.FrameAvatarToBounds`** — places the avatar camera on its own view axis, `dist` behind the bounds center (`position = center − forward · dist`), so the emote is fit **and** centered regardless of the camera's fixed pitch. Orthographic mode sizes the lens instead of dollying. `SetMode` resets the camera pose/lens on every reload so framing is idempotent. **Zoom still owns FOV** — framing only touches position, so the two never fight.
- **`PreviewController`** — uses camera framing for the emote path; the **wearable path keeps `CenterAndFit` unchanged**.

Side benefits: the avatar staying at scale 1 makes spring-bone lossyScale compensation a no-op (neutral/simpler), and decouples framing from the transform the `DragRotator` owns.

## Testing

Verified in the Unity editor (Play mode, debug panel) with the issue's emote (`0xc242…4fc6:0`, "Barrel Roll"), which **shrinks** the avatar mid-animation:

- Whole emote fits; avatar is **normal-sized and centered at idle**, and **small while the emote plays** (as intended).
- On return to idle the avatar is **no longer giant/too close** (the reported bug).
- Bone envelope measured correctly (~2.6 m for the barrel roll, centered near origin) and varies with the pose — confirmed via instrumentation (since removed).
- `Assembly-CSharp` compiles clean (batch-mode build).

### Still worth a manual pass
- Emote **prop** and **audio** URLs (sampling restores playback via `ReplayEmote`).
- Wearable previews (should be visually unchanged).
- Zoom in/out on an emote; orthographic projection (`&projection=orthographic`).
- The background highlight rectangle still hugging the avatar (data tweak to `highlightSize` if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

BEFORE:


https://github.com/user-attachments/assets/f9f71d92-1d8f-40b8-a943-84e013761c0b


AFTER:



https://github.com/user-attachments/assets/206fc91e-6a96-407e-b229-958f61bb4c98

