### PR TITLE
fix: cap preview device pixel ratio and framerate to reduce gpu cost

### DIFF
--- a/Assets/Scripts/Bootstrap.cs
+++ b/Assets/Scripts/Bootstrap.cs
@@ -15,6 +15,14 @@ public class Bootstrap : MonoBehaviour
 
     private void Start()
     {
+        // The preview is near-static, so cap the frame rate to keep GPU/CPU
+        // cost low on consumers. VSync must be disabled first: while it is on
+        // (QualitySettings.vSyncCount != 0) Application.targetFrameRate is
+        // ignored and rendering is tied to the display refresh (120Hz+ on
+        // ProMotion / high-refresh screens).
+        QualitySettings.vSyncCount = 0;
+        Application.targetFrameRate = 30;
+
         // Common assets
         CommonAssets.AvatarMaterial = baseMat;
         CommonAssets.FacialFeaturesMaterial = facialFeaturesMat;

--- a/Assets/WebGLTemplates/Fullscreen/index.html
+++ b/Assets/WebGLTemplates/Fullscreen/index.html
@@ -53,6 +53,14 @@
 
     <script src="Build/{{{ LOADER_FILENAME }}}"></script>
     <script>
+      // Cap the device pixel ratio. Unity otherwise renders at the full
+      // window.devicePixelRatio (4-9x the pixels on Retina/HiDPI displays),
+      // which pegs the GPU for a preview that is nearly static.
+      // Overridable via a ?dpr= query param so consumers can tune it; the
+      // default cap is 1.5.
+      var dprParam = parseFloat(new URLSearchParams(window.location.search).get("dpr"));
+      var dprCap = isNaN(dprParam) ? 1.5 : dprParam;
+
       createUnityInstance(document.querySelector("#unity-canvas"), {
         arguments: [],
         dataUrl: "Build/{{{ DATA_FILENAME }}}",
@@ -71,6 +79,7 @@
         productName: {{{ JSON.stringify(PRODUCT_NAME) }}},
         productVersion: {{{ JSON.stringify(PRODUCT_VERSION) }}},
         matchWebGLToCanvasSize: true,
+        devicePixelRatio: Math.min(window.devicePixelRatio || 1, dprCap),
       }).then(function(unityInstance) {
 #if SHOW_DIAGNOSTICS
         // Open diagnostics when user clicks the icon


### PR DESCRIPTION
## Problem

The WebGL wearable preview (aang) renders at the full `devicePixelRatio` and at an uncapped framerate, which pegs GPU/CPU on consumers (the shop PDP became nearly unusable on Retina / high-refresh displays).

- The deployed WebGL template (`Fullscreen`, referenced by `ProjectSettings/ProjectSettings.asset` as `webGLTemplate: PROJECT:Fullscreen`) never set `config.devicePixelRatio`, so Unity rendered at full DPR — 4-9x the pixels on Retina.
- `ProjectSettings/QualitySettings.asset` has `vSyncCount: 1`, tying rendering to the display refresh (120fps+ on ProMotion / 144Hz). There was no `Application.targetFrameRate` set anywhere.

## Changes

- **`Assets/WebGLTemplates/Fullscreen/index.html`**: cap `config.devicePixelRatio` to `Math.min(window.devicePixelRatio || 1, 1.5)`. The cap is overridable via a `?dpr=` query param (default `1.5`) so consumers can tune it per-embed. This mirrors the builder's existing mitigation (which forces `window.devicePixelRatio = 1`).
- **`Assets/Scripts/Bootstrap.cs`**: on startup set `Application.targetFrameRate = 30` (previews are near-static). Because `targetFrameRate` is ignored while VSync is enabled, `QualitySettings.vSyncCount = 0` is set first, at runtime, so the frame-rate cap actually takes effect. Runtime disable was chosen over editing the asset so the intent is co-located with the cap and applies regardless of the active quality level.

`Fullscreen` is the only active template — the stock `Default` template in the repo is not referenced by `ProjectSettings` and is left untouched.

An on-demand rendering approach (`OnDemandRendering.renderFrameInterval`, rendering only on rotation/emote/asset changes) would cut cost further but needs reliable change-detection wiring and build testing; `targetFrameRate = 30` is the safe baseline and is left as a possible follow-up.

## Note on deployment

These changes only take effect after the WebGL project is **rebuilt via Unity Cloud** and the built preview is **redeployed**. The C# frame-rate cap is compiled into the build; the template `devicePixelRatio` cap is baked into the generated `index.html` at build time. Consumers that embed the hosted WearablePreview (e.g. the shop PDP, marketplace, builder) pick it up once the new build is live — no consumer-side code change is required.

## Test plan

- [ ] Rebuild via Unity Cloud and confirm the generated `index.html` contains the `devicePixelRatio` cap.
- [ ] On a Retina / high-refresh display, confirm the preview renders at capped DPR and ~30fps and GPU usage drops.
- [ ] Confirm `?dpr=` override changes the render resolution.
- [ ] Confirm rotation / emote playback / asset swap still animate smoothly at 30fps.