### PR TITLE
fix: render the avatar as is when marketplace mode gets no urns

### DIFF
--- a/Assets/Scripts/Preview/PreviewController.cs
+++ b/Assets/Scripts/Preview/PreviewController.cs
@@ -169,13 +169,9 @@ namespace Preview
                     switch (config.Mode)
                     {
                         case PreviewMode.Marketplace:
+                            // With no urns there is nothing to override, so the profile avatar is the
+                            // whole preview.
                             var urns = await LoadUrns(config);
-                            // A real check and not an Assert: asserts are stripped from release WebGL
-                            // builds, so anything guarded by one fails silently where it matters.
-                            if (urns is not { Count: > 0 })
-                                throw new InvalidOperationException(
-                                    "Marketplace mode requires at least one urn, or a contract with an item or token id");
-
                             var result = await LoadForMarketplace(config.Profile, urns, config.Emote);
 
                             previewUIPresenter.EnableEmoteControls(result.emoteOverride);
@@ -376,7 +372,7 @@ namespace Preview
 
                 // There is no locked item view to fall back to here, and rendering the profile avatar
                 // wearing none of the requested items would be a silent lie, so report it instead.
-                if (renderableOverrides.Count == 0 && emoteOverride == null)
+                if (wearableOverrides.Count > 0 && renderableOverrides.Count == 0 && emoteOverride == null)
                     throw new NotSupportedException(
                         $"None of the requested urns have a {avatarBodyShape} representation: {string.Join(", ", urns)}");
 
@@ -466,7 +462,7 @@ namespace Preview
                 };
             }
 
-            return null;
+            return new List<string>();
         }
 
         public void Cleanup()


### PR DESCRIPTION
## Problem

Marketplace mode crashed when given no urns. A preview like
`?mode=marketplace&profile=default1` (no `urn`, no `contract` + `itemId`/`tokenId`)
threw instead of rendering anything, and the error surfaced through
`JSBridge.NativeCalls.OnError`. The reasonable reading of that request is
"show the profile avatar with nothing overridden".

## Cause

Two guards, both in `PreviewController`:

- `LoadUrns` returned `null` for the no-urn case, and the `PreviewMode.Marketplace`
  branch of `Reload` turned that into an `InvalidOperationException`.
- `LoadForMarketplace` had a second guard that threw `NotSupportedException`
  ("none of the requested urns have a `<bodyshape>` representation") whenever
  `renderableOverrides` was empty — technically true with zero urns, but
  meaningless, since nothing was requested to begin with.

## Fix

- `LoadUrns` returns an empty list instead of `null`, so the override-resolution
  loop is a no-op rather than a null deref.
- Dropped the mode-level throw in `Reload`.
- Scoped the representation guard to `wearableOverrides.Count > 0`, so it only
  fires when items were actually requested and none of them are renderable for
  the avatar's body shape — its real purpose.

That's the right seam because the rest of `LoadForMarketplace` already degrades
correctly on an empty override set: `showsItemAlone` is false, so the item-alone
view is cleaned up and the switcher stays disabled, `validRepresentation` is true,
and the avatar loads with all slots filled from its own profile wearables under the
usual marketplace camera, zoom and auto-rotate. Net result is the profile-mode
render with marketplace controls.

Existing behaviour with one or more urns is untouched.

## Tests

No automated tests — this is a Unity project with no headless test or build script
in the repo, so compilation and the empty-urn render path have not been verified by
CI or locally; both need the Editor. The change is confined to control flow in one
method plus one return value, with no API changes. Worth a manual check of
`?mode=marketplace` with no urns, and a regression pass on single-urn and
multi-urn previews, before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)