### PR TITLE
Fix: face texture masks white lines

### DIFF
--- a/Assets/Scripts/Bootstrap.cs
+++ b/Assets/Scripts/Bootstrap.cs
@@ -2,6 +2,8 @@ using Configurator;
 using GLTFast;
 using Preview;
 using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
 
 public class Bootstrap : MonoBehaviour
 {
@@ -29,6 +31,16 @@ public class Bootstrap : MonoBehaviour
         // and rendering is tied to the display refresh (120Hz+ on ProMotion / high-refresh screens).
         QualitySettings.vSyncCount = 0;
         Application.targetFrameRate = AangConfiguration.Instance.Fps;
+
+        // Small viewports (e.g. marketplace thumbnails) get supersampled for extra quality since the
+        // absolute shaded pixel count stays bounded (under 1600x1600 -> under 3200x3200). Both
+        // dimensions must be under the threshold, not just one, so a wide-but-short viewport doesn't
+        // get its large dimension doubled too.
+        if (Screen.width < 1600 && Screen.height < 1600)
+        {
+            var urpAsset = (UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline;
+            urpAsset.renderScale = 2f;
+        }
 
         if (AangConfiguration.Instance.UninterruptedDeferAgent)
         {

--- a/Assets/Scripts/Bootstrap.cs
+++ b/Assets/Scripts/Bootstrap.cs
@@ -37,7 +37,11 @@ public class Bootstrap : MonoBehaviour
         // dimensions must be under the threshold, not just one, so a wide-but-short viewport doesn't
         // get its large dimension doubled too.
         if (Screen.width < 1600 && Screen.height < 1600)
+        if (GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset urpAsset
+            && Screen.width < 1600 && Screen.height < 1600)
         {
+            urpAsset.renderScale = 2f;
+        }
             var urpAsset = (UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline;
             urpAsset.renderScale = 2f;
         }

--- a/Assets/Settings/URP_Asset.asset
+++ b/Assets/Settings/URP_Asset.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   m_SupportsTerrainHoles: 1
   m_SupportsHDR: 1
   m_HDRColorBufferPrecision: 1
-  m_MSAA: 4
+  m_MSAA: 1
   m_RenderScale: 1
   m_UpscalingFilter: 0
   m_FsrOverrideSharpness: 0
@@ -129,11 +129,11 @@ MonoBehaviour:
   m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 0
   m_PrefilterScreenCoord: 1
-  m_PrefilterScreenSpaceIrradiance: 0
+  m_PrefilterScreenSpaceIrradiance: 1
   m_PrefilterNativeRenderPass: 1
   m_PrefilterUseLegacyLightmaps: 0
   m_PrefilterBicubicLightmapSampling: 1
-  m_PrefilterReflectionProbeRotation: 0
+  m_PrefilterReflectionProbeRotation: 1
   m_PrefilterReflectionProbeBlending: 1
   m_PrefilterReflectionProbeBoxProjection: 1
   m_PrefilterReflectionProbeAtlas: 1

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -22,7 +22,7 @@ QualitySettings:
     globalTextureMipmapLimit: 0
     textureMipmapLimitSettings: []
     anisotropicTextures: 2
-    antiAliasing: 4
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 0


### PR DESCRIPTION
Fix for transparent textures bleeding/fringe, disabled MSAA antialiasing and set to upscale the renderer when the render window is small to have better outlines.