### PR TITLE
fix: remove duplicated supersampling block breaking compilation

### DIFF
--- a/Assets/Scripts/Bootstrap.cs
+++ b/Assets/Scripts/Bootstrap.cs
@@ -36,13 +36,9 @@ public class Bootstrap : MonoBehaviour
         // absolute shaded pixel count stays bounded (under 1600x1600 -> under 3200x3200). Both
         // dimensions must be under the threshold, not just one, so a wide-but-short viewport doesn't
         // get its large dimension doubled too.
-        if (Screen.width < 1600 && Screen.height < 1600)
         if (GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset urpAsset
             && Screen.width < 1600 && Screen.height < 1600)
         {
-            urpAsset.renderScale = 2f;
-        }
-            var urpAsset = (UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline;
             urpAsset.renderScale = 2f;
         }
 


### PR DESCRIPTION
## Problem

Unity Cloud Build is failing on `main`. The job for 5afe0c9 ("Fix: face texture masks white lines" #74) failed all 3 retry attempts with:

```
Aborting batchmode due to failure: Scripts have compiler errors.
```

The previous run (ef2b5b5) was green.

## Cause

`Bootstrap.Start` in `Assets/Scripts/Bootstrap.cs`. The small-viewport supersampling block added by #74 landed in a broken state — looks like a bad merge or a half-applied edit. It contained a dangling brace-less `if`, then a complete `if` block, then two orphaned statements and an extra closing brace:

```csharp
if (Screen.width < 1600 && Screen.height < 1600)      // dangling if, no braces
if (GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset urpAsset
    && Screen.width < 1600 && Screen.height < 1600)
{
    urpAsset.renderScale = 2f;
}
    var urpAsset = (UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline;  // orphan
    urpAsset.renderScale = 2f;                                                            // orphan
}                                                                                          // extra brace
```

That extra brace closes `Start()` early, so everything after it parses as class-level members instead of statements — 15 errors across CS1519, CS8124, CS1026, CS8803, CS1022 and CS0106.

## Fix

Keep only the pattern-match version of the block. It already performs the both-dimensions check that the comment above it describes, and it null-guards via `is UniversalRenderPipelineAsset` rather than the unchecked cast the orphaned lines used. Net change is `-4` lines; the supersampling behaviour #74 intended is preserved.

## Tests

No test suite covers this file. Verified by compiling `Bootstrap.cs` with the Roslyn compiler bundled in the project's Unity install (`6000.3.6f1/.../DotNetSdkRoslyn/csc.dll`):

- `main`'s version: 12 matching syntax errors
- this branch: 0

That run is `-nostdlib`, so it is a parse/syntax check rather than a full type-check against the Unity assemblies. The Cloud Build job on this PR is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
