### PR TITLE
fix: honour caller skin, hair and eye color in marketplace mode

### DIFF
--- a/Assets/Scripts/Preview/PreviewController.cs
+++ b/Assets/Scripts/Preview/PreviewController.cs
@@ -38,7 +38,7 @@ namespace Preview
         private const string PREF_AVATAR_SHOWN = "PreviewAvatarShown";
 
         // #cc9b76, the skin the JS wrapper used to send whenever a builder caller left it out.
-        private static readonly Color DEFAULT_SKIN_COLOR = new(0.8f, 0.607f, 0.462f);
+        private static readonly Color DEFAULT_SKIN_COLOR = new(204f / 255f, 155f / 255f, 118f / 255f);
 
         private bool _loading;
         private bool _shouldReload;

--- a/Assets/Scripts/Preview/PreviewController.cs
+++ b/Assets/Scripts/Preview/PreviewController.cs
@@ -37,6 +37,9 @@ namespace Preview
         // survives across sessions: only ever a fallback, never an override of what was requested.
         private const string PREF_AVATAR_SHOWN = "PreviewAvatarShown";
 
+        // #cc9b76, the skin the JS wrapper used to send whenever a builder caller left it out.
+        private static readonly Color DEFAULT_SKIN_COLOR = new(0.8f, 0.607f, 0.462f);
+
         private bool _loading;
         private bool _shouldReload;
         private bool _shouldCleanup;
@@ -172,7 +175,7 @@ namespace Preview
                             // With no urns there is nothing to override, so the profile avatar is the
                             // whole preview.
                             var urns = await LoadUrns(config);
-                            var result = await LoadForMarketplace(config.Profile, urns, config.Emote);
+                            var result = await LoadForMarketplace(config, urns);
 
                             previewUIPresenter.EnableEmoteControls(result.emoteOverride);
 
@@ -301,7 +304,8 @@ namespace Preview
             }
             var wearableEntities = slots.Values.ToArray();
 
-            var colors = new AvatarColors(eyeColor ?? Color.black, hairColor ?? Color.black, skinColor ?? Color.black);
+            var colors = new AvatarColors(eyeColor ?? Color.black, hairColor ?? Color.black,
+                skinColor ?? DEFAULT_SKIN_COLOR);
 
             var emoteEntity = base64Emote ?? (emoteName == "idle" ? null : EntityDefinition.FromEmbeddedEmote(emoteName, true));
 
@@ -319,14 +323,20 @@ namespace Preview
 
         private async Awaitable<(bool emoteOverride, bool emoteOverrideAudio, bool validRepresentation,
                 bool showsItemAlone, BodyShape avatarBodyShape)>
-            LoadForMarketplace(string profileID, List<string> urns, string defaultEmote)
+            LoadForMarketplace(AangConfiguration config, List<string> urns)
         {
+            var profileID = config.Profile;
+            var defaultEmote = config.Emote;
+
             Assert.IsNotNull(profileID);
             Assert.IsNotNull(defaultEmote);
 
             var avatar = await APIService.GetAvatar(profileID);
             var avatarBodyShape = avatar.GetBodyShape();
-            var avatarColors = avatar.GetAvatarColors();
+            var profileColors = avatar.GetAvatarColors();
+            // A caller-supplied color wins so combinations can be tried on any profile; the rest stay the profile's.
+            var avatarColors = new AvatarColors(config.EyeColor ?? profileColors.Eyes,
+                config.HairColor ?? profileColors.Hair, config.SkinColor ?? profileColors.Skin);
             var allEntities = await EntityService.GetEntities(avatar.wearables.Concat(urns).ToArray());
 
             // Resolve in request order so that, when two urns compete for the same slot below, the last


### PR DESCRIPTION
## Problem

With `mode=marketplace`, the `skinColor` / `hairColor` / `eyeColor` URL params and the matching
`SetSkinColor` / `SetHairColor` / `SetEyeColor` JSBridge calls were silently dropped. A consumer
could not let a user try color combinations on an avatar the way `mode=builder` allows.

Repro (through the wearable-preview wrapper):
`…/?unity=true&mode=marketplace&profile=default1&skin=%23ff0000` renders `default1`'s own skin, not red.

## Cause

`PreviewController.LoadForMarketplace` took its colors straight from the fetched profile
(`avatar.GetAvatarColors()`). `AangConfiguration.SkinColor / HairColor / EyeColor` — populated from
both the URL and the bridge — were only ever read in the `PreviewMode.Builder` branch.

## Fix

`LoadForMarketplace` merges the two: a color the caller asked for wins, and every channel left unset
keeps the profile's own. Both views follow for free, since the avatar (`avatarLoader.LoadAvatar`) and
the item-alone view (`wearableLoader.LoadWearable`) already receive the same `AvatarColors`. That
also makes it work regardless of the `profile` param — a real address, a `defaultN`, or none at all.

The method now takes the `AangConfiguration` snapshot `Reload()` already holds (matching `LoadUrns`)
instead of individual values, so it never reaches for the singleton that `RecreateFrom` can swap
mid-load.

`LoadForBuilder`'s skin fallback moves from `Color.black` to `#cc9b76` — the value the
wearable-preview wrapper has always sent on every builder request. The companion wrapper PR
(decentraland/wearable-preview) stops sending colors nobody asked for, which is what keeps
profile-less marketplace previews on their default profile's colors; without this constant it would
leave builder callers with black skin.

## Tests

No test project in this repo, so this is untested here beyond compiling. The wrapper side of the
change is verified in the companion PR (color params now travel only when the caller asks). Worth a
manual pass on: marketplace with an explicit `skin`, marketplace with only a `profile`, marketplace
with neither, and builder with no color params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)