### PR TITLE
fix: stop material-less glTF primitives from glowing

### DIFF
--- a/Assets/Scripts/Loading/ToonMaterialGenerator.cs
+++ b/Assets/Scripts/Loading/ToonMaterialGenerator.cs
@@ -124,8 +124,13 @@ namespace Loading
 
         public Material GetDefaultMaterial(bool pointsSupport = false)
         {
-            // I don't think this is ever called
-            return CommonAssets.AvatarMaterial;
+            // Called for primitives with no material. The Avatar_Toon template carries an
+            // authored HDR _Emissive_Color, so return a copy with it zeroed to match the
+            // glTF default material (and the explorer), instead of the glowing shared asset.
+            var mat = new Material(CommonAssets.AvatarMaterial) { name = "Default_MAT" };
+            mat.SetColor(EMISSIVE_COLOR_ID, Color.black);
+            mat.SetInt(CULL_MODE_ID, (int)CullMode.Back);
+            return mat;
         }
 
         public void SetLogger(ICodeLogger logger)

--- a/Assets/Scripts/Loading/ToonMaterialGenerator.cs
+++ b/Assets/Scripts/Loading/ToonMaterialGenerator.cs
@@ -25,6 +25,8 @@ namespace Loading
 
         //private readonly AvatarColors _avatarColors;
 
+        private Material m_DefaultMaterial;
+
         public ToonMaterialGenerator()
         {
             
@@ -127,10 +129,15 @@ namespace Loading
             // Called for primitives with no material. The Avatar_Toon template carries an
             // authored HDR _Emissive_Color, so return a copy with it zeroed to match the
             // glTF default material (and the explorer), instead of the glowing shared asset.
-            var mat = new Material(CommonAssets.AvatarMaterial) { name = "Default_MAT" };
-            mat.SetColor(EMISSIVE_COLOR_ID, Color.black);
-            mat.SetInt(CULL_MODE_ID, (int)CullMode.Back);
-            return mat;
+            // Cached so multiple material-less primitives in the same GLB share one instance.
+            if (m_DefaultMaterial == null)
+            {
+                m_DefaultMaterial = new Material(CommonAssets.AvatarMaterial) { name = "Default_MAT" };
+                m_DefaultMaterial.SetColor(EMISSIVE_COLOR_ID, Color.black);
+                m_DefaultMaterial.SetColor(BASE_COLOR_ID, Color.white);
+                m_DefaultMaterial.SetInt(CULL_MODE_ID, (int)CullMode.Back);
+            }
+            return m_DefaultMaterial;
         }
 
         public void SetLogger(ICodeLogger logger)


### PR DESCRIPTION
## Problem

Wearable geometry that has no glTF material assigned renders as a blown-out white glow in aang-renderer, while the explorer (and the Babylon preview) render it flat. Repro: load `Shirt_SpringBones` in the builder item editor with the Unity renderer — the two front panels bloom bright white. The GLB authors no emissive anywhere — its third primitive simply has no material.

| AANG-RENDERER | BABYLON | UNITY CLIENT (EXPLORER) |
| --- | --- | --- |
| <img width="347" height="440" alt="image" src="https://github.com/user-attachments/assets/0e63f020-b978-4b59-b233-d419151ed3c7" /> | <img width="277" height="479" alt="image" src="https://github.com/user-attachments/assets/6283fa8a-2cfe-4080-92d7-1188e4c9937e" /> | <img width="277" height="337" alt="image" src="https://github.com/user-attachments/assets/70060caf-bf0c-4ce1-9535-b92901878c3e" /> <img width="341" height="363" alt="image" src="https://github.com/user-attachments/assets/e18a8039-e882-402a-8c7a-08eaa095839a" /> |

## Cause

`ToonMaterialGenerator.GetDefaultMaterial()` — the path glTFast takes for material-less primitives — returned the shared `Avatar_Toon.mat` template asset directly (its comment claimed it was never called). That asset carries a leftover authored HDR `_Emissive_Color = (4.237, 4.237, 4.237)`; `DCL_ToonBodyDoubleShadeWithFeather.hlsl` multiplies it by ×2.5 with a white default `_Emissive_Tex`, so the geometry emitted ≈10.6 linear and URP bloom + ACES turned it into the halo.

## Fix

`GetDefaultMaterial()` now returns a copy of the template with `_Emissive_Color` zeroed and backface culling set, matching the glTF default material and the explorer's behavior. Returning a copy also stops loads from mutating the shared asset. `GenerateMaterial()` is unaffected — it always overwrites `_Emissive_Color` for materials that exist in the file.

Results:

| BABYLON (original) | AANG-RENDERER (current PR) |
| --- | --- |
| <img width="284" height="431" alt="image" src="https://github.com/user-attachments/assets/63e05c0f-454a-4e7d-99f3-14db8c777754" /> | <img width="346" height="437" alt="image" src="https://github.com/user-attachments/assets/88a3d443-18ce-4b50-86c2-65880ff23d6c" /> |


